### PR TITLE
Default value for state

### DIFF
--- a/src/Reducer/ComposedReducer.php
+++ b/src/Reducer/ComposedReducer.php
@@ -51,7 +51,8 @@ class ComposedReducer extends CallableReducer
     public function reduce($state, array $action)
     {
         foreach ($this->reducers as $key => $reducer) {
-            $state[$key] = $reducer($state[$key], $action);
+            $currentState = isset($state[$key]) ? $state[$key] : null;
+            $state[$key] = $reducer($currentState, $action);
         }
 
         return $state;


### PR DESCRIPTION
Added support to have a default value for the state when using ComposedReducer.

The current behavior throws an error saying "Undefined index: {key}".

The responsibility to specify the initial state is given to the reducer.

Example:

```php
$reducer->addReducer('list', function($state=[], $action) {
    switch ($action['type']) {
       case 'my_action':
            $state[] = $action['payload'];
        break;
    }
    return $state;
});

 \Rb\Redux\Store::create($reducer, []); // error was throwing on this line before the change
```